### PR TITLE
Use filetype to determine whitespace stripping.

### DIFF
--- a/plugin/spacejam.vim
+++ b/plugin/spacejam.vim
@@ -7,11 +7,17 @@ if exists("g:loaded_spacejam") || &cp
 endif
 let g:loaded_spacejam = 1
 
+if !exists('g:spacejam_filetypes')
+  let g:spacejam_filetypes = 'ruby,javascript,vim,perl'
+endif
+
 command! -range=% Trim <line1>,<line2>call s:Trim()
 
 if has("autocmd")
   augroup spacejam
-    autocmd BufWritePre .vimrc,*.rb,*.py,*.js call AutoTrim()
+    let g:spacejam_autocmd = "autocmd FileType " . g:spacejam_filetypes . " :autocmd! BufWritePre <buffer> call AutoTrim()"
+
+    exec g:spacejam_autocmd
   augroup END
 endif
 

--- a/spec/plugin/spacejam_spec.rb
+++ b/spec/plugin/spacejam_spec.rb
@@ -1,0 +1,88 @@
+require 'spec_helper'
+
+shared_context "strips trailing whitespace" do
+  it "strips whitespace" do
+    write_file(filename, sample_text)
+
+    vim.edit filename
+    vim.write
+
+    expect(File.read(filename)).to eql(sample_text.strip + "\n")
+  end
+end
+
+describe "spacejam.vim" do
+  let(:default_filetypes) { 'ruby,javascript,vim,perl' }
+  let(:plugin_path) { File.expand_path('../../../',__FILE__) }
+
+  context "overriding defaults" do
+    before do
+      vim.command "let g:spacejam_filetypes = 'markdown'"
+      vim.add_plugin(plugin_path, 'plugin/spacejam.vim')
+    end
+
+    let(:filename) { 'test.md' }
+    let(:sample_text) { "# Test header   " }
+
+    it "strips whitespace" do
+      write_file(filename, sample_text)
+
+      puts vim.echo 'g:spacejam_filetypes'
+      vim.edit filename
+      puts vim.command "au * <buffer>"
+      vim.write
+
+      expect(File.read(filename)).to eql(sample_text.strip + "\n")
+    end
+  end
+
+  context "default filetypes" do
+    before do
+      vim.add_plugin(plugin_path, 'plugin/spacejam.vim')
+    end
+
+    it "sets up a global variable for the list of filetypes" do
+      expect(vim.echo "g:spacejam_filetypes").to eql(default_filetypes)
+    end
+
+    context "ruby" do
+      let(:sample_text) { "blah = 'test'    " }
+
+      context ".rb files" do
+        let(:filename)    { 'test.rb' }
+        include_context "strips trailing whitespace"
+      end
+
+      context ".rake files" do
+        let(:filename)    { 'test.rake' }
+        include_context "strips trailing whitespace"
+      end
+
+      context "Gemfile files" do
+        let(:filename)    { 'Gemfile' }
+        include_context "strips trailing whitespace"
+      end
+    end
+
+    context "javascript files" do
+      let(:filename) { 'test.js' }
+      let(:sample_text) { "var blah = 'test'   " }
+
+      include_context "strips trailing whitespace"
+    end
+
+    context "vim files" do
+      let(:filename) { 'test.vim' }
+      let(:sample_text) { "let l:blah = 'test'   " }
+
+      include_context "strips trailing whitespace"
+    end
+
+    context "perl files" do
+      let(:filename) { 'test.pl' }
+      let(:sample_text) { "$blah='test';    " }
+
+      include_context "strips trailing whitespace"
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,0 +1,21 @@
+require 'tmpdir'
+require 'vimrunner'
+require 'vimrunner/rspec'
+
+Vimrunner::RSpec.configure do |config|
+  # Use a single Vim instance for the test suite. Set to false to use an
+  # instance per test (slower, but can be easier to manage).
+  config.reuse_server = false
+
+  # Decide how to start a Vim instance. In this block, an instance should be
+  # spawned and set up with anything project-specific.
+  config.start_vim do
+    vim = Vimrunner.start
+
+    # Or, start a GUI instance:
+    # vim = Vimrunner.start_gvim
+
+    # The returned value is the Client available in the tests.
+    vim
+  end
+end

--- a/spec/support/ruby_file_with_whitespace.rb
+++ b/spec/support/ruby_file_with_whitespace.rb
@@ -1,0 +1,3 @@
+
+blah = "balh blah blah"
+


### PR DESCRIPTION
The main reason is to allow each filetype to specify which patterns
match. For example ruby files can be more than just '*.rb' (Gemfile,
*.rake, etc). 

This change also allows the user to override 'g:spacejam_filetypes' with
a different list of filetypes. This makes the list of filetypes
configurable.

I have also used the
[vimrunner](https://github.com/AndrewRadev/vimrunner) gem to test the
plugin.  

There is still an error with the spec for user overrides, but I'd like
to get some input on whether this direction will be accepted before
spending too much time trying to figure it out.
