### PR TITLE
Add Elixir support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,17 @@
 # Vim SpaceJam
 
 Simple plugin designed to prevent trailing whitespace from sneaking into commits.
+
+### Development
+
+```
+$ git clone git@github.com:rondale-sc/vim-spacejam.git
+$ cd vim-spacejam.git
+```
+
+### Testing
+
+```
+$ gem install vimrunner
+$ rspec
+```

--- a/plugin/spacejam.vim
+++ b/plugin/spacejam.vim
@@ -8,7 +8,7 @@ endif
 let g:loaded_spacejam = 1
 
 if !exists('g:spacejam_filetypes')
-  let g:spacejam_filetypes = 'ruby,javascript,vim,perl,sass,scss,css,coffee,haml'
+  let g:spacejam_filetypes = 'ruby,javascript,vim,perl,sass,scss,css,coffee,haml,elixir'
 endif
 
 command! -range=% Trim <line1>,<line2>call s:Trim()

--- a/spec/plugin/spacejam_spec.rb
+++ b/spec/plugin/spacejam_spec.rb
@@ -12,7 +12,7 @@ shared_context "strips trailing whitespace" do
 end
 
 describe "spacejam.vim" do
-  let(:default_filetypes) { 'ruby,javascript,vim,perl' }
+  let(:default_filetypes) { 'ruby,javascript,vim,perl,sass,scss,css,coffee,haml' }
   let(:plugin_path) { File.expand_path('../../../',__FILE__) }
 
   context "overriding defaults" do

--- a/spec/plugin/spacejam_spec.rb
+++ b/spec/plugin/spacejam_spec.rb
@@ -12,7 +12,7 @@ shared_context "strips trailing whitespace" do
 end
 
 describe "spacejam.vim" do
-  let(:default_filetypes) { 'ruby,javascript,vim,perl,sass,scss,css,coffee,haml' }
+  let(:default_filetypes) { 'ruby,javascript,vim,perl,sass,scss,css,coffee,haml,elixir' }
   let(:plugin_path) { File.expand_path('../../../',__FILE__) }
 
   context "overriding defaults" do

--- a/spec/plugin/spacejam_spec.rb
+++ b/spec/plugin/spacejam_spec.rb
@@ -75,5 +75,21 @@ describe "spacejam.vim" do
 
       include_context "strips trailing whitespace"
     end
+
+    context "elixir" do
+      context ".exs files" do
+        let(:filename) { 'test.exs' }
+        let(:sample_text) { "blah = 'test'    " }
+
+        include_context "strips trailing whitespace"
+      end
+
+      context ".ex files" do
+        let(:filename) { 'test.ex' }
+        let(:sample_text) { "blah = 'test'    " }
+
+        include_context "strips trailing whitespace"
+      end
+    end
   end
 end

--- a/spec/support/ruby_file_with_whitespace.rb
+++ b/spec/support/ruby_file_with_whitespace.rb
@@ -1,3 +1,0 @@
-
-blah = "balh blah blah"
-


### PR DESCRIPTION
This commit adds (or attempts to add) whitespace removal for Elixir filetypes.

ac0433e tests the feature; currently both examples are failing. However, I believe this is due to test setup (Vimrunner or MacVim not recognizing Elixir filetypes), because adding the change to my local installation of the plugin did in fact lead to automatic whitespace removal for Elixir files.

Thanks!