### PR TITLE
Allow disabling auto trim auto-command

### DIFF
--- a/doc/spacejam.txt
+++ b/doc/spacejam.txt
@@ -15,6 +15,11 @@ COMMANDS                                        *spacejam-commands*
 
 :Trim  Remove extra whitespace from current buffer. Optionally accepts range, defaults to whole file.
 
+CONFIGURATION                                   *spacejam-configuration*
+
+To disable automatic trimming on save, add `let g:spacejam_autocmd=''` before
+loading the plugin.
+
 ABOUT                                           *spacejam-about*
 
 :credit

--- a/plugin/spacejam.vim
+++ b/plugin/spacejam.vim
@@ -15,7 +15,9 @@ command! -range=% Trim <line1>,<line2>call s:Trim()
 
 if has('autocmd')
   augroup spacejam
-    let g:spacejam_autocmd = 'autocmd FileType ' . g:spacejam_filetypes . ' :autocmd! BufWritePre <buffer> call s:AutoTrim()'
+    if !exists('g:spacejam_autocmd')
+      let g:spacejam_autocmd = 'autocmd FileType ' . g:spacejam_filetypes . ' :autocmd! BufWritePre <buffer> call s:AutoTrim()'
+    endif
 
     exec g:spacejam_autocmd
   augroup END

--- a/plugin/spacejam.vim
+++ b/plugin/spacejam.vim
@@ -2,7 +2,7 @@
 " Author: Jonathan Jackson
 " Version: 1.0
 
-if exists("g:loaded_spacejam") || &cp
+if exists('g:loaded_spacejam') || &cp
   finish
 endif
 let g:loaded_spacejam = 1
@@ -13,9 +13,9 @@ endif
 
 command! -range=% Trim <line1>,<line2>call s:Trim()
 
-if has("autocmd")
+if has('autocmd')
   augroup spacejam
-    let g:spacejam_autocmd = "autocmd FileType " . g:spacejam_filetypes . " :autocmd! BufWritePre <buffer> call s:AutoTrim()"
+    let g:spacejam_autocmd = 'autocmd FileType ' . g:spacejam_filetypes . ' :autocmd! BufWritePre <buffer> call s:AutoTrim()'
 
     exec g:spacejam_autocmd
   augroup END
@@ -23,8 +23,8 @@ endif
 
 function! s:Trim() range
   let _s=@/
-  let l = line(".")
-  let c = col(".")
+  let l = line('.')
+  let c = col('.')
 
   for lineno in range(a:firstline, a:lastline)
     let line = getline(lineno)
@@ -38,8 +38,8 @@ endfunction
 
 function! s:AutoTrim()
   let _s=@/
-  let l = line(".")
-  let c = col(".")
+  let l = line('.')
+  let c = col('.')
 
   %s/\s\+$//e
 

--- a/spec/plugin/spacejam_spec.rb
+++ b/spec/plugin/spacejam_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
-shared_context "strips trailing whitespace" do
-  it "strips whitespace" do
+shared_context 'strips trailing whitespace' do
+  it 'strips whitespace' do
     write_file(filename, sample_text)
 
     vim.edit filename
@@ -11,72 +11,72 @@ shared_context "strips trailing whitespace" do
   end
 end
 
-describe "spacejam.vim" do
+describe 'spacejam.vim' do
   let(:default_filetypes) do
     'ruby,javascript,vim,perl,sass,scss,css,coffee,haml'
   end
 
-  let(:plugin_path) { File.expand_path('../../../',__FILE__) }
+  let(:plugin_path) { File.expand_path('../../../', __FILE__) }
 
-  context "overriding defaults" do
+  context 'overriding defaults' do
     before do
       vim.command "let g:spacejam_filetypes = 'html'"
       vim.add_plugin(plugin_path, 'plugin/spacejam.vim')
     end
 
     let(:filename) { 'test.html' }
-    let(:sample_text) { "<h1>Test</h1>" }
+    let(:sample_text) { '<h1>Test</h1>' }
 
-    include_context "strips trailing whitespace"
+    include_context 'strips trailing whitespace'
   end
 
-  context "default filetypes" do
+  context 'default filetypes' do
     before do
       vim.add_plugin(plugin_path, 'plugin/spacejam.vim')
     end
 
-    it "sets up a global variable for the list of filetypes" do
-      expect(vim.echo "g:spacejam_filetypes").to eql(default_filetypes)
+    it 'sets up a global variable for the list of filetypes' do
+      expect(vim.echo('g:spacejam_filetypes')).to eql(default_filetypes)
     end
 
-    context "ruby" do
+    context 'ruby' do
       let(:sample_text) { "blah = 'test'    " }
 
-      context ".rb files" do
+      context '.rb files' do
         let(:filename)    { 'test.rb' }
-        include_context "strips trailing whitespace"
+        include_context 'strips trailing whitespace'
       end
 
-      context ".rake files" do
-        let(:filename)    { 'test.rake' }
-        include_context "strips trailing whitespace"
+      context '.rake files' do
+        let(:filename) { 'test.rake' }
+        include_context 'strips trailing whitespace'
       end
 
-      context "Gemfile files" do
-        let(:filename)    { 'Gemfile' }
-        include_context "strips trailing whitespace"
+      context 'Gemfile files' do
+        let(:filename) { 'Gemfile' }
+        include_context 'strips trailing whitespace'
       end
     end
 
-    context "javascript files" do
+    context 'javascript files' do
       let(:filename) { 'test.js' }
       let(:sample_text) { "var blah = 'test'   " }
 
-      include_context "strips trailing whitespace"
+      include_context 'strips trailing whitespace'
     end
 
-    context "vim files" do
+    context 'vim files' do
       let(:filename) { 'test.vim' }
       let(:sample_text) { "let l:blah = 'test'   " }
 
-      include_context "strips trailing whitespace"
+      include_context 'strips trailing whitespace'
     end
 
-    context "perl files" do
+    context 'perl files' do
       let(:filename) { 'test.pl' }
       let(:sample_text) { "$blah='test';    " }
 
-      include_context "strips trailing whitespace"
+      include_context 'strips trailing whitespace'
     end
   end
 end

--- a/spec/plugin/spacejam_spec.rb
+++ b/spec/plugin/spacejam_spec.rb
@@ -30,6 +30,25 @@ describe 'spacejam.vim' do
     include_context 'strips trailing whitespace'
   end
 
+  context 'disabling auto trim' do
+    before do
+      vim.command "let g:spacejam_autocmd = ''"
+      vim.add_plugin(plugin_path, 'plugin/spacejam.vim')
+    end
+
+    let(:filename) { 'test.rb' }
+    let(:sample_text) { "blah = 'test'    \n" }
+
+    it 'does not strip whitespace' do
+      write_file(filename, sample_text)
+
+      vim.edit filename
+      vim.write
+
+      expect(File.read(filename)).to eql(sample_text)
+    end
+  end
+
   context 'default filetypes' do
     before do
       vim.add_plugin(plugin_path, 'plugin/spacejam.vim')

--- a/spec/plugin/spacejam_spec.rb
+++ b/spec/plugin/spacejam_spec.rb
@@ -12,7 +12,10 @@ shared_context "strips trailing whitespace" do
 end
 
 describe "spacejam.vim" do
-  let(:default_filetypes) { 'ruby,javascript,vim,perl' }
+  let(:default_filetypes) do
+    'ruby,javascript,vim,perl,sass,scss,css,coffee,haml'
+  end
+
   let(:plugin_path) { File.expand_path('../../../',__FILE__) }
 
   context "overriding defaults" do

--- a/spec/support/ruby_file_with_whitespace.rb
+++ b/spec/support/ruby_file_with_whitespace.rb
@@ -1,3 +1,2 @@
 
-blah = "balh blah blah"
-
+blah = 'balh blah blah'


### PR DESCRIPTION
Some of the guys here were having problems with legacy code being changed wildly on save and wanted a way to disable the auto trim functionality. This PR allows that (see documentation).

Additionally:
- linted code with rubocop and vim
- fixed a previously broken spec regarding default file types
